### PR TITLE
Fixed issue with Polymer/paper-elements

### DIFF
--- a/lib/detect-dependencies.js
+++ b/lib/detect-dependencies.js
@@ -175,8 +175,10 @@ function gatherInfo(config) {
 
     if (dep.main.length === 0 && !depIsExcluded) {
       // can't find the main file. this config file is useless!
-      config.get('on-main-not-found')(component);
-      return;
+      onfig.get('on-main-not-found')(component);
+      // Polymer/paper-elements comes with a missing main but has useful dependencies
+      // skipping the return correctly includes the transient dependencies
+      // return;
     }
 
     if (componentConfigFile.dependencies) {


### PR DESCRIPTION
Polymer comes with a meta-component paper-elements. This component does not have a main file but depends on the rest of the components for Polymer.

Commenting out the return correctly includes these dependencies.